### PR TITLE
Update to 1.19.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.12-SNAPSHOT'
+	id 'fabric-loom' version '1.0-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
 org.gradle.jvmargs=-Xmx1G
 
-minecraft_version=1.19
-yarn_mappings=1.19+build.1
-loader_version=0.14.6
+minecraft_version=1.19.3
+yarn_mappings=1.19.3+build.5
+loader_version=0.14.12
 
 #Fabric api
-fabric_version=0.55.2+1.19
+fabric_version=0.72.0+1.19.3
 
-mod_version = 0.5+1.19
+mod_version = 0.5+1.19.3
 maven_group = io.github.foundationgames
 archives_base_name = animatica
 	

--- a/src/main/java/io/github/foundationgames/animatica/animation/AnimationLoader.java
+++ b/src/main/java/io/github/foundationgames/animatica/animation/AnimationLoader.java
@@ -12,11 +12,13 @@ import net.minecraft.util.Identifier;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.function.BiConsumer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 
 public final class AnimationLoader implements SimpleSynchronousResourceReloadListener {

--- a/src/main/java/io/github/foundationgames/animatica/animation/bakery/AnimationBakery.java
+++ b/src/main/java/io/github/foundationgames/animatica/animation/bakery/AnimationBakery.java
@@ -1,17 +1,20 @@
 package io.github.foundationgames.animatica.animation.bakery;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
 import io.github.foundationgames.animatica.Animatica;
 import io.github.foundationgames.animatica.animation.AnimationMeta;
 import io.github.foundationgames.animatica.util.TextureUtil;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.texture.NativeImage;
 import net.minecraft.client.texture.NativeImageBackedTexture;
+import net.minecraft.client.texture.TextureManager;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;

--- a/src/main/java/io/github/foundationgames/animatica/config/AnimaticaConfig.java
+++ b/src/main/java/io/github/foundationgames/animatica/config/AnimaticaConfig.java
@@ -6,6 +6,8 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.SimpleOption;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;

--- a/src/main/java/io/github/foundationgames/animatica/mixin/RenderSystemMixin.java
+++ b/src/main/java/io/github/foundationgames/animatica/mixin/RenderSystemMixin.java
@@ -3,6 +3,7 @@ package io.github.foundationgames.animatica.mixin;
 import com.mojang.blaze3d.systems.RenderSystem;
 import io.github.foundationgames.animatica.Animatica;
 import io.github.foundationgames.animatica.animation.AnimationLoader;
+import io.github.foundationgames.animatica.animation.BakedTextureAnimation;
 import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;

--- a/src/main/java/io/github/foundationgames/animatica/util/PropertyUtil.java
+++ b/src/main/java/io/github/foundationgames/animatica/util/PropertyUtil.java
@@ -1,6 +1,7 @@
 package io.github.foundationgames.animatica.util;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
 import io.github.foundationgames.animatica.util.exception.InvalidPropertyException;
 import io.github.foundationgames.animatica.util.exception.MissingPropertyException;
 import io.github.foundationgames.animatica.util.exception.PropertyParseException;


### PR DESCRIPTION
The previous version already seems to work as is on Minecraft 1.19.3, but I saw the "issue" and thought I should do a version bump PR. I updated the mod according to [this Fabric guide](https://fabricmc.net/wiki/tutorial:migratemappings). All the code changes are from `gradlew migrateMappings`.

I tested the recompiled mod and at least animated item textures are working (didn't have a resource pack with other animated features at hand).