### PR TITLE
Compile for 1.21.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,7 @@ plugins {
 	id 'fabric-loom' version "${loom_version}"
 }
 
-sourceCompatibility = JavaVersion.VERSION_21
-targetCompatibility = JavaVersion.VERSION_21
-
-archivesBaseName = project.archives_base_name
+base.archivesName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
 
@@ -17,7 +14,7 @@ dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
 }
 
 processResources {
@@ -39,6 +36,6 @@ java {
 
 jar {
 	from("LICENSE") {
-		rename { "${it}_${project.archivesBaseName}"}
+		rename { "${it}_${project.base.archivesName}"}
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,13 @@
 org.gradle.jvmargs=-Xmx1G
 
-minecraft_version=1.21.5
-yarn_mappings=1.21.5+build.1
-loader_version=0.16.14
-loom_version=1.10-SNAPSHOT
+minecraft_version=1.21.11
+yarn_mappings=1.21.11+build.4
+loader_version=0.18.4
+loom_version=1.15-SNAPSHOT
 
 # Fabric API
-fabric_version=0.127.1+1.21.5
+fabric_api_version=0.141.2+1.21.11
 
-mod_version = 0.6.1+1.21.5
+mod_version = fabric-0.6.1+1.21.11
 maven_group = io.github.foundationgames
 archives_base_name = animatica
-	

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Compiled with no errors on 1.21.11. 

Tested with Recolourful Containers (villager trading screen animations)

Added "fabric" to the version name so that the loader is clear just from the build